### PR TITLE
PERFORMANCE IMPROVEMENT

### DIFF
--- a/anodet/feature_extraction.py
+++ b/anodet/feature_extraction.py
@@ -39,6 +39,7 @@ class ResnetEmbeddingsExtractor(torch.nn.Module):
         self.backbone.to(device)
         self.backbone.eval()
         self.eval()
+        self.device = device
 
     def to_device(self, device: torch.device) -> None:
         """Perform device conversion on backone
@@ -110,7 +111,7 @@ class ResnetEmbeddingsExtractor(torch.nn.Module):
         embedding_vectors: Optional[torch.Tensor] = None
 
         for (batch, _, _) in tqdm(dataloader, 'Feature extraction'):
-
+            batch = batch.to(self.device)
             batch_embedding_vectors = self(batch,
                                            channel_indices=channel_indices,
                                            layer_hook=layer_hook,

--- a/anodet/patch_core.py
+++ b/anodet/patch_core.py
@@ -139,6 +139,7 @@ class PatchCore:
         print('initial embedding size : ', embedding_vectors.shape)
         print('final embedding size : ', self.embedding_coreset.shape)
 
+
     def predict(self,
                 batch: torch.Tensor,
                 n_neighbors: int = 9,
@@ -171,7 +172,7 @@ class PatchCore:
                                                       layer_indices=self.layer_indices
                                                       )
 
-        knn = KNN(torch.from_numpy(self.embedding_coreset).to(str(self.device)), k=n_neighbors)
+        knn = KNN(torch.from_numpy(self.embedding_coreset).to(self.device), k=n_neighbors)
         patch_width = int(math.sqrt(embedding_vectors.shape[1]))
         score_maps = torch.zeros((embedding_vectors.shape[0], batch.shape[2], batch.shape[2]))
 


### PR DESCRIPTION
Inference speed highly increased from 6s to 2s for the 5 images used in the notebook. Now also support CUDA and speed is increased to 0,02s using a RTX 3090

Based on your sample images from notebook
```
# load test Images
DATASET_PATH = os.path.realpath("../../datasets/MVTec")
paths = [
    os.path.join(DATASET_PATH, "bottle/test/broken_large/000.png"),
    os.path.join(DATASET_PATH, "bottle/test/broken_small/000.png"),
    os.path.join(DATASET_PATH, "bottle/test/contamination/000.png"),
    os.path.join(DATASET_PATH, "bottle/test/good/000.png"),
    os.path.join(DATASET_PATH, "bottle/test/good/001.png"),
```

I meassured the total time making predicitons
```
print('Making predictions')
tik = time.time()
image_scores, score_maps = patch_core.predict(batch) # Make prediction
tok = time.time()
print("Done")
print(tok - tik)
```

This is the result
![image](https://user-images.githubusercontent.com/37028633/150005071-ea8429b4-cb13-44cc-a0d8-bae63c149cb5.png)

Now the performance have been highly increasd by CPU

![image](https://user-images.githubusercontent.com/37028633/150005267-b2fdbefe-f7d3-48fe-98f9-19b5f706236b.png)

And now neighbour search support supports GPU

![image](https://user-images.githubusercontent.com/37028633/150005326-57c430e6-50a4-4a1f-8dcd-776b84293a89.png)

